### PR TITLE
Simple changes to JSON file removes PHP strict mode warnings

### DIFF
--- a/config.json
+++ b/config.json
@@ -15,12 +15,16 @@
     {
       "name": "grid",
       "width": 980,
-      "update": 300
+      "update": 300,
+      "class": "",
+      "args": {
+      }
     },
     {
       "name": "countdown",
       "width": 980,
       "update": 3600,
+      "class": "",
       "args": {
         "event": "UNTIL SOMETHING",
         "stop": 1274706000,
@@ -61,28 +65,42 @@
     {
       "name": "space",
       "width": 300,
-      "update": 0
+      "update": 0,
+      "class": "",
+      "args": {
+      }
     },
     {
       "name": "bubblelist",
       "width": 200,
       "update": 0,
-      "class": "mini bluegradient"
+      "class": "mini bluegradient",
+      "args": {
+      }
     },
     {
       "name": "newsticker",
       "width": 980,
-      "update": 3600
+      "update": 3600,
+      "class": "",
+      "args": {
+      }
     },
     {
       "name": "stockticker",
       "width": 980,
-      "update": 3600
+      "update": 3600,
+      "class": "",
+      "args": {
+      }
     },
     {
       "name": "meta",
       "width": 980,
-      "update": 0
+      "update": 0,
+      "class": "",
+      "args": {
+      }
     }
   ]
 }


### PR DESCRIPTION
Add empty / missing values to JSON file so PHP strict mode emits no warnings.

Signed-off-by: James Van Lommel <jamesvl@gmail.com>